### PR TITLE
Deprecate confirm delivery

### DIFF
--- a/Omnibee/lib/pages/explore/customCardIcon.dart
+++ b/Omnibee/lib/pages/explore/customCardIcon.dart
@@ -1,0 +1,25 @@
+import 'package:Omnibee/models/models.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class CustomCardIcon extends StatelessWidget {
+  final Order order;
+
+  CustomCardIcon(this.order);
+
+  @override
+  Widget build(BuildContext context) {
+    if (order.isReceived) {
+      return Icon(Icons.check_circle, color: Colors.green, size: 45);
+    } else if (order.isExpired()) {
+      return Icon(Icons.cancel, color: Colors.red, size: 45);
+    } else if (order.smallRestaurantImage != null) {
+      return Image(
+        image: AssetImage(order.smallRestaurantImage),
+        fit: BoxFit.fill,
+      );
+    } else {
+      return Icon(Icons.fastfood, size: 45);
+    }
+  }
+}

--- a/Omnibee/lib/pages/explore/deliveryCard.dart
+++ b/Omnibee/lib/pages/explore/deliveryCard.dart
@@ -1,3 +1,4 @@
+import 'package:Omnibee/services/paymentService.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:Omnibee/models/models.dart';
@@ -56,6 +57,28 @@ class DeliveryCardButtonBar extends StatelessWidget {
 
   DeliveryCardButtonBar(this.order, this.context);
 
+  void _markOrderComplete(Order order, BuildContext context) {
+    final snackBar = SnackBar(
+      content: Text('Confirming delivery, please wait one moment....'),
+    );
+    Scaffold.of(context).showSnackBar(snackBar);
+
+    double pCharge = order.price;
+    double applicationFee = order.applicationFee;
+
+    print(
+        "MarkOrderComplete: pcharge is $pCharge and applicationFee is $applicationFee");
+
+    PaymentService.paymentTransfer(
+      order,
+      context,
+      pCharge,
+      applicationFee,
+      order.paymentMethodId,
+      order.stripeAccountId,
+    );
+  }
+
   List<Widget> _getButtons() {
     List<Widget> buttons = [
       RaisedButton(
@@ -69,6 +92,7 @@ class DeliveryCardButtonBar extends StatelessWidget {
         ),
         onPressed: () {
           BlocProvider.of<OrderBloc>(context).add(OrderMarkDelivered(order));
+          _markOrderComplete(order, context);
         },
       ),
       FlatButton(
@@ -82,6 +106,7 @@ class DeliveryCardButtonBar extends StatelessWidget {
       ),
     ];
 
+    //TODO: keep here for testing purposes and then remove
     if (order.isDelivered) {
       buttons.removeAt(0);
       if (!order.isReceived) {

--- a/Omnibee/lib/pages/explore/deliveryCard.dart
+++ b/Omnibee/lib/pages/explore/deliveryCard.dart
@@ -1,3 +1,4 @@
+import 'package:Omnibee/pages/explore/customCardIcon.dart';
 import 'package:Omnibee/services/paymentService.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +26,6 @@ class DeliveryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // if (order.isComplete()) return Container();
     return GestureDetector(
       onTap: () {},
       child: Card(
@@ -38,7 +38,7 @@ class DeliveryCard extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             ExpansionTile(
-                leading: Icon(Icons.fastfood),
+                leading: CustomCardIcon(order),
                 title: Text(order.name + ": " + order.restaurantName),
                 subtitle: Text(order.getDeliveryWindow() +
                     "\nEarnings: \$${order.minEarnings.toStringAsFixed(2)}"),
@@ -100,8 +100,14 @@ class DeliveryCardButtonBar extends StatelessWidget {
           'VIEW DETAILS',
           style: TextStyle(fontSize: 18),
         ),
-        onPressed: () {
-          Navigator.pushNamed(context, '/delivery_card_page', arguments: order);
+        onPressed: () async {
+          final deliveredOrder = await Navigator.pushNamed(
+              context, '/delivery_card_page',
+              arguments: order);
+          if (deliveredOrder != null) {
+            BlocProvider.of<OrderBloc>(context).add(OrderMarkDelivered(order));
+            _markOrderComplete(order, context);
+          }
         },
       ),
     ];

--- a/Omnibee/lib/pages/explore/explore_card/deliveryCardPage.dart
+++ b/Omnibee/lib/pages/explore/explore_card/deliveryCardPage.dart
@@ -17,10 +17,10 @@ class DeliveryCardPage extends StatelessWidget {
   final double boldFontSize = 22;
 
   void _markOrderComplete(Order order, BuildContext context) {
-    final snackBar = SnackBar(
+    /* final snackBar = SnackBar(
       content: Text('Confirming delivery, please wait one moment....'),
     );
-    Scaffold.of(context).showSnackBar(snackBar);
+    Scaffold.of(context).showSnackBar(snackBar); */
 
     double pCharge = order.price;
     double applicationFee = order.applicationFee;
@@ -53,9 +53,9 @@ class DeliveryCardPage extends StatelessWidget {
             ),
           ),
           onPressed: () {
-            BlocProvider.of<OrderBloc>(context).add(OrderMarkDelivered(order));
-            _markOrderComplete(order, context);
-            Navigator.pop(context);
+            //BlocProvider.of<OrderBloc>(context).add(OrderMarkDelivered(order));
+            //_markOrderComplete(order, context);
+            Navigator.pop(context, true);
           },
         ),
       );

--- a/Omnibee/lib/pages/explore/explore_card/deliveryCardPage.dart
+++ b/Omnibee/lib/pages/explore/explore_card/deliveryCardPage.dart
@@ -16,6 +16,28 @@ class DeliveryCardPage extends StatelessWidget {
   final double fontSize = 19;
   final double boldFontSize = 22;
 
+  void _markOrderComplete(Order order, BuildContext context) {
+    final snackBar = SnackBar(
+      content: Text('Confirming delivery, please wait one moment....'),
+    );
+    Scaffold.of(context).showSnackBar(snackBar);
+
+    double pCharge = order.price;
+    double applicationFee = order.applicationFee;
+
+    print(
+        "MarkOrderComplete: pcharge is $pCharge and applicationFee is $applicationFee");
+
+    PaymentService.paymentTransfer(
+      order,
+      context,
+      pCharge,
+      applicationFee,
+      order.paymentMethodId,
+      order.stripeAccountId,
+    );
+  }
+
   Widget _controlButtons(Order order, BuildContext context) {
     if (order.isDelivered) {
       return Container();
@@ -32,6 +54,7 @@ class DeliveryCardPage extends StatelessWidget {
           ),
           onPressed: () {
             BlocProvider.of<OrderBloc>(context).add(OrderMarkDelivered(order));
+            _markOrderComplete(order, context);
             Navigator.pop(context);
           },
         ),

--- a/Omnibee/lib/pages/explore/orderCard.dart
+++ b/Omnibee/lib/pages/explore/orderCard.dart
@@ -112,24 +112,24 @@ class OrderCardButtonBar extends StatelessWidget {
         },
       ),
     ];
-
-    if (order.isDelivered == true && !order.isExpired() && !order.isReceived) {
-      buttons.insert(
-          0,
-          RaisedButton(
-            color: Color(0xffFD9827),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(18.0),
-            ),
-            child: const Text(
-              'CONFIRM DELIVERY',
-              style: TextStyle(fontSize: 18, color: Colors.white),
-            ),
-            onPressed: () {
-              _markOrderComplete(order, context);
-            },
-          ));
-    }
+    //TODO: remove once tested
+    // if (order.isDelivered == true && !order.isExpired() && !order.isReceived) {
+    //   buttons.insert(
+    //       0,
+    //       RaisedButton(
+    //         color: Color(0xffFD9827),
+    //         shape: RoundedRectangleBorder(
+    //           borderRadius: BorderRadius.circular(18.0),
+    //         ),
+    //         child: const Text(
+    //           'CONFIRM DELIVERY',
+    //           style: TextStyle(fontSize: 18, color: Colors.white),
+    //         ),
+    //         onPressed: () {
+    //           _markOrderComplete(order, context);
+    //         },
+    //       ));
+    // }
 
     return buttons;
   }

--- a/Omnibee/lib/pages/explore/orderCard.dart
+++ b/Omnibee/lib/pages/explore/orderCard.dart
@@ -1,4 +1,5 @@
 import 'package:Omnibee/bloc/auth/auth_bloc.dart';
+import 'package:Omnibee/pages/explore/customCardIcon.dart';
 import 'package:Omnibee/services/paymentService.dart';
 import 'package:flutter/material.dart';
 import 'package:Omnibee/models/models.dart';
@@ -22,16 +23,6 @@ class OrderCard extends StatelessWidget {
     return children;
   }
 
-  Widget _getIcon(Order order) {
-    if (order.isReceived) {
-      return Icon(Icons.check_circle, color: Colors.green, size: 45);
-    } else if (order.isExpired()) {
-      return Icon(Icons.cancel, color: Colors.red, size: 45);
-    } else {
-      return Icon(Icons.fastfood, size: 45);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -47,14 +38,10 @@ class OrderCard extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               ExpansionTile(
-                  leading: _getIcon(order),
+                  leading: CustomCardIcon(order),
                   title: Text(order.name + ": " + order.restaurantName),
                   subtitle: Text("${order.getDeliveryWindow()}"),
                   children: _itemsToOrder(order)),
-              Image(
-                image: AssetImage(order.bigRestaurantImage),
-                fit: BoxFit.none,
-              ),
               OrderCardButtonBar(order, context),
             ],
           ),

--- a/Omnibee/lib/services/paymentService.dart
+++ b/Omnibee/lib/services/paymentService.dart
@@ -19,7 +19,7 @@ class PaymentService {
   }
 
   static double getTaxedPrice(double price) {
-    double taxRate = 0.1255; //0.08;
+    double taxRate = 0.08; //0.08;
     return _round((taxRate * price) + price);
   }
 
@@ -177,7 +177,7 @@ class PaymentService {
       ));
       _paymentCallback(order, val.status);
     }).catchError((error, stackTrace) {
-      print("error!");
+      print("error: $error");
     }).whenComplete(() async {
       _printSuccess(context);
     });


### PR DESCRIPTION
Problem:
Need to automatically do transfer when runner clicks confirm delivery, shouldn't have extra step for requester

Solution:
Got rid of last step, money now transferred when confirm delivery clicked

Test:
Ran several tests on iphone simulators